### PR TITLE
Reduce bundle size from @solana/spl-token-registry import

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -1,8 +1,8 @@
-import { ENV } from "@solana/spl-token-registry";
 import { PublicKey } from "@solana/web3.js";
 import { AssetConfig, AssetContext } from "./models";
 import { PORT_LENDING, PORT_STAKING } from "./constants";
 import { MAINNET_ASSETS } from "./utils/AssetConfigs";
+import { ENV } from "./utils/env";
 
 export class Environment {
   private readonly env: ENV;

--- a/src/models/ReserveContext.ts
+++ b/src/models/ReserveContext.ts
@@ -3,7 +3,7 @@ import { ReserveInfo } from "./ReserveInfo";
 import { ReserveId } from "./ReserveId";
 import { StakingPoolId } from "./staking/StakingPoolId";
 import { OracleId } from "./OracleId";
-import { TokenInfo } from "@solana/spl-token-registry";
+import type { TokenInfo } from "@solana/spl-token-registry";
 
 export class ReserveContext {
   private static readonly RESERVE_CONTEXT_EMPTY = new ReserveContext(

--- a/src/models/staking/StakingPool.ts
+++ b/src/models/staking/StakingPool.ts
@@ -12,7 +12,7 @@ import { AssetPrice } from "../AssetPrice";
 import { StakingPoolLayout, StakingPoolProto } from "../../structs";
 import { AuthorityId } from "../AuthorityId";
 import Big from "big.js";
-import { TokenInfo } from "@solana/spl-token-registry";
+import type { TokenInfo } from "@solana/spl-token-registry";
 import { QuantityContext } from "..";
 
 const SLOT_PER_SECOND = 2;

--- a/src/utils/AssetConfigs.ts
+++ b/src/utils/AssetConfigs.ts
@@ -6,7 +6,7 @@ import {
   MintId,
   ReserveId,
 } from "../models";
-import { ENV } from "@solana/spl-token-registry";
+import { ENV } from "./env";
 
 export const DEVNET_BTC = new AssetConfig(
   MintId.fromBase58("EbwEYuUQHxcSHszxPBhA2nT2JxhiNwJedwjsctJnLmsC"),

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,5 @@
+export enum ENV {
+  MainnetBeta = 101,
+  Testnet = 102,
+  Devnet = 103,
+}


### PR DESCRIPTION
This PR updates imports from `@solana/spl-token-registry` to be type-imports only. When importing `ENV` from `@solana/spl-token-registry`, it bloats the size of the package by over 200kB because it imports the entire token registry JSON into the final built package.

To avoid this, I have defined the `ENV` enum local to the project, and changed all imports of the library to use `import type`. I have tested this locally and it reduces the bundle size for consumers of this library by quite a bit (~600 kB if using both `port-sdk` and `port-stats`).